### PR TITLE
16:9を維持しつつレスポンシブ対応

### DIFF
--- a/cm.html
+++ b/cm.html
@@ -94,19 +94,19 @@
       <h2 id="movie"><img src="images/cm/h2-movie.png"></h2>
 
       <section class="main-slider">
-        <div class="item youtube">
+        <div class="item youtube iframe-wrapper">
           <iframe class="embed-player slide-media" src="https://www.youtube.com/embed/T8UcWyatYIw?enablejsapi=1&controls=1&fs=0&iv_load_policy=3&rel=0&showinfo=0&playlist=T8UcWyatYIw;start=107;end=128&modestbranding=1&mute=1&autoplay=1" frameborder="0" allowfullscreen></iframe>
         </div>
 
-        <div class="item youtube">
+        <div class="item youtube iframe-wrapper">
           <iframe class="embed-player slide-media" src="https://www.youtube.com/embed/Hm2g2zcEr5I?enablejsapi=1&controls=1&fs=0&iv_load_policy=3&rel=0&showinfo=0&playlist=Hm2g2zcEr5I;start=48;end=56&mute=1&autoplay=1"  allowfullscreen frameborder="0"></iframe>
         </div>
 
-        <div class="item youtube">
+        <div class="item youtube iframe-wrapper">
           <iframe class="embed-player slide-media" src="https://www.youtube.com/embed/T8UcWyatYIw?enablejsapi=1&controls=1&fs=0&iv_load_policy=3&rel=0&showinfo=0&playlist=T8UcWyatYIw;start=107;end=128&mute=1&autoplay=1"  allowfullscreen frameborder="0"></iframe>
         </div>
 
-        <div class="item youtube">
+        <div class="item youtube iframe-wrapper">
           <iframe class="embed-player slide-media" src="https://www.youtube.com/embed/Hm2g2zcEr5I?enablejsapi=1&controls=1&fs=0&iv_load_policy=3&rel=0&showinfo=0&playlist=Hm2g2zcEr5I;start=48;end=56&mute=1&autoplay=1" allowfullscreen frameborder="0"></iframe>
         </div>
       </section>

--- a/css/cm.css
+++ b/css/cm.css
@@ -17,6 +17,25 @@ iframe {
   height: 540px;
 }
 
+.iframe-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.iframe-wrapper:before {
+  content: '';
+  display: block;
+  padding-top: 56.25%; /* 縦横比16:9 */
+}
+
+.iframe-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100% !important;
+}
+
 .slick-arrow {
   background-color: #f08d24;
   height: 100%;


### PR DESCRIPTION
何故かスマホサイズにした時にiframe内にインラインスタイルでheight: 0が指定されていたため、
表示されないように見えていた。なので、あまり使いたくはないがそっちの原因解明よりも!imporatnt
を使って対処した。